### PR TITLE
Migrate README frontmatter to the new tutorial metadata schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 ---
 author: Jūlija Pečerska,Veronika Bošková,Louis du Plessis
-level: Beginner
 title: Introduction to BEAST2
-beastversion: 2.7.x
 tracerversion: 1.7.x
 figtreeversion: 1.4.x
 subtitle: This is a simple introductory tutorial to help you get started with using BEAST2 and its accomplices.
+beastversion_tutorial: 2.7.x
+workflow: Getting started
+status: current
+keywords:
+- molecular clock
+- substitution models
+- site models
+- nucleotide
+- Bayesian inference
+packages:
+- CCD
+domains:
+- macroevolution
 ---
 
 


### PR DESCRIPTION
Updates this tutorial's README frontmatter to the schema at
https://github.com/taming-the-beast/taming-the-beast.github.io/blob/master/tutorials/tutorial_schema.yml

- renames `beastversion` -> `beastversion_tutorial`, `tutorial_type` -> `workflow`
- removes the unused `level` field
- adds `workflow`, `status`, `keywords`, `packages`, `domains`

The values come from the central `tutorials_metadata.yml` in the Taming the BEAST
repository, where they are currently maintained as a fallback. Moving them here makes
this repo the source of truth again and lets the tutorial appear correctly in the
filters on https://taming-the-beast.org/tutorials/.

Please correct anything that looks wrong. The metadata added here was reviewed
centrally, not by the tutorial authors.
